### PR TITLE
Enable tasks to report file accesses

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHostTaskComplete_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostTaskComplete_Tests.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             parameters2.Add("MyBoolValue", true);
             parameters2.Add("MyITaskItem", new TaskItem("ABC"));
             parameters2.Add("ItemArray", new ITaskItem[] { new TaskItem("DEF"), new TaskItem("GHI"), new TaskItem("JKL") });
-            _ = new
-            TaskHostTaskComplete(new OutOfProcTaskHostTaskResult(TaskCompleteType.Success, parameters2), default, null);
+            _ = new TaskHostTaskComplete(new OutOfProcTaskHostTaskResult(TaskCompleteType.Success, parameters2), default, null);
         }
 
         /// <summary>

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -401,16 +401,16 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <inheritdoc/>
-            public void Translate(ref List<FileAccessData> value)
+            public void Translate(ref List<FileAccessData> fileAccessDataList)
             {
-                if (!TranslateNullable(value))
+                if (!TranslateNullable(fileAccessDataList))
                 {
                     return;
                 }
 
                 int count = default;
                 Translate(ref count);
-                value = new List<FileAccessData>(count);
+                fileAccessDataList = new List<FileAccessData>(count);
                 for (int i = 0; i < count; i++)
                 {
                     ReportedFileOperation reportedFileOperation = default;
@@ -433,7 +433,7 @@ namespace Microsoft.Build.BackEnd
                     Translate(ref path);
                     Translate(ref processArgs);
                     Translate(ref isAnAugmentedFileAccess);
-                    value.Add(new FileAccessData(
+                    fileAccessDataList.Add(new FileAccessData(
                         reportedFileOperation,
                         requestedAccess,
                         processId,
@@ -1106,8 +1106,16 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <inheritdoc/>
-            public void Translate(ref List<FileAccessData> value) =>
-                value.ForEach(fileAccessData =>
+            public void Translate(ref List<FileAccessData> fileAccessDataList)
+            {
+                if (!TranslateNullable(fileAccessDataList))
+                {
+                    return;
+                }
+
+                int count = fileAccessDataList.Count;
+                Translate(ref count);
+                fileAccessDataList.ForEach(fileAccessData =>
                 {
                     ReportedFileOperation reportedFileOperation = fileAccessData.Operation;
                     RequestedAccess requestedAccess = fileAccessData.RequestedAccess;
@@ -1130,6 +1138,7 @@ namespace Microsoft.Build.BackEnd
                     Translate(ref processArgs);
                     Translate(ref isAnAugmentedFileAccess);
                 });
+            }
 #endif 
 
             /// <summary>

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -235,10 +235,10 @@ namespace Microsoft.Build.BackEnd
         void Translate(ref BuildEventContext value);
 
         /// <summary>
-        /// Translates <paramref name="value"/>.
+        /// Translates <paramref name="fileAccessDataList"/>.
         /// </summary>
-        /// <param name="value">The file accesses to translate.</param>
-        void Translate(ref List<FileAccessData> value);
+        /// <param name="fileAccessDataList">The file accesses to translate.</param>
+        void Translate(ref List<FileAccessData> fileAccessDataList);
 #endif 
 
         /// <summary>


### PR DESCRIPTION
### Changes Made
Enables tasks to report file accesses to the build engine. In the case of the `OutOfProcTaskHostNode`, `fileAccessData` is sent to the `TaskHostTask` via the `TaskHostTaskComplete` packet, which is sent upon task completion.

Additionally, needed to move the file access data structures to the `Microsoft.Build.Framework` project to avoid creating a circular dependency with the `EngineServices` abstract class.

### Notes
https://github.com/dfederm/msbuild/commit/45f4cf74641cb5736ff43446a783c7e49c6f3dd5 can also be erased from history since Detours won't be used for reporting.